### PR TITLE
Fix log prefix

### DIFF
--- a/lua/kaleidosearch/init.lua
+++ b/lua/kaleidosearch/init.lua
@@ -71,7 +71,7 @@ local default_config = {
 local function log(msg, level)
   level = level or vim.log.levels.INFO
   if M.config.debug or level == vim.log.levels.ERROR then
-    print("[org-history] " .. msg, level)
+    print("[kaleidosearch] " .. msg, level)
   end
 end
 


### PR DESCRIPTION
## Summary
- fix log prefix so debug messages use `[kaleidosearch]`

## Testing
- `bash scripts/run_tests.sh` *(fails: `nvim: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684049f9d8108333b47b38dbc9aa0b10